### PR TITLE
Github Actions: Changes triggers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,12 @@
 name: Tests
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   test:
@@ -60,4 +66,3 @@ jobs:
 
       - name: Execute tests
         run: vendor/bin/phpunit
-


### PR DESCRIPTION
- Only trigger builds on push to `main`
- Trigger builds on multiple pull request events.
- This avoids jobs being triggered twice when a new PR is created.
