### PR TITLE
add laravel 9 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 7.3, 7.4, 8.0 ]
-        laravel: [ 7.*, 8.* ]
+        laravel: [ 7.*, 8.*, 9.* ]
         dependency-version: [ prefer-lowest, prefer-stable ]
         include:
           - laravel: 7.*
@@ -24,6 +24,16 @@ jobs:
 
           - laravel: 8.*
             testbench: 6.*
+
+          - laravel: 9.*
+            testbench: 7.*
+
+        exclude:
+          - laravel: 9.*
+            php: 7.3
+
+          - laravel: 9.*
+            php: 7.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
@@ -54,15 +64,17 @@ jobs:
         run: vendor/bin/phpunit
 
       - name: Install Livewire V1
+        if: "! startsWith(matrix.laravel, '9.')"
         run: |
           composer require "livewire/livewire:^1" --no-interaction
 
       - name: Execute tests
+        if: "! startsWith(matrix.laravel, '9.')"
         run: vendor/bin/phpunit
 
       - name: Install Livewire V2
         run: |
-          composer require "livewire/livewire:^2" --no-interaction
+          composer require "livewire/livewire:^2.3.10" -W --${{ matrix.dependency-version }} --no-interaction
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -17,18 +17,18 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "illuminate/support": "^7.26.0|^8.0",
-        "illuminate/console": "^7.26.0|^8.0",
-        "illuminate/http": "^7.26.0|^8.0",
-        "illuminate/cache": "^7.26.0|^8.0",
-        "illuminate/view": "^7.26.0|^8.0",
+        "illuminate/support": "^7.26.0|^8.0|^9.0",
+        "illuminate/console": "^7.26.0|^8.0|^9.0",
+        "illuminate/http": "^7.26.0|^8.0|^9.0",
+        "illuminate/cache": "^7.26.0|^8.0|^9.0",
+        "illuminate/view": "^7.26.0|^8.0|^9.0",
         "guzzlehttp/guzzle": "^7.2",
         "ramsey/uuid": "^3.7|^4.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0|^6.0",
+        "orchestra/testbench": "^5.0|^6.0|^7.0",
         "mockery/mockery": "^1.3.3",
-        "phpunit/phpunit": "^8.4"
+        "phpunit/phpunit": "^8.4|^9.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- update `composer.json` to add Laravel 9
- update github workflow to include Laravel 9
  - I need to add `-W` flag when installing livewire v2, otherwise there will be a conflict when running `P8 - L9.* prefer-lowest`
  - Livewire v1 only support Laravel version < 9, so I am excluding them for Laravel 9.
