### PR TITLE
Fix deprecation error messages on PHP 8.1

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -223,7 +223,7 @@ class Block
         $attrs = [];
 
         foreach ($this->attrs as $key => $value) {
-            $value = addslashes($value);
+            $value = addslashes($value ?? '');
             $attrs[] = "$key=\"$value\"";
         }
 
@@ -263,7 +263,7 @@ class Block
     {
         $this->clones = [];
 
-        $themes = explode(',', $this->theme);
+        $themes = explode(',', $this->theme ?? '');
 
         // Set the theme for the current block, so that we
         // don't break the reference to it.


### PR DESCRIPTION
See torchlight-api/torchlight-jigsaw#5. This is also fixing more warnings during Jigsaw builds.