### PR TITLE
Fix absolute path

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -155,7 +155,9 @@ class Manager
         array_unshift($directories, '');
 
         foreach ($directories as $directory) {
-            $directory = Str::finish($directory, DIRECTORY_SEPARATOR);
+            if (!empty($directory)) {
+                $directory = Str::finish($directory, DIRECTORY_SEPARATOR);
+            }
 
             if (is_file($directory . $file)) {
                 return file_get_contents($directory . $file);


### PR DESCRIPTION
An absolute path starts with an extra /
For example, /c:/... or //var/...
This causes a path error in windows