### PR TITLE
Add support for Livewire V3

### DIFF
--- a/src/Middleware/RenderTorchlight.php
+++ b/src/Middleware/RenderTorchlight.php
@@ -47,18 +47,14 @@ class RenderTorchlight
 
         $data = $response->getData();
 
-        if (data_get($data, 'effects.html'))
-        {
+        if (data_get($data, 'effects.html')) {
             // livewire v2
             $html = BladeManager::renderContent(data_get($data, 'effects.html'));
 
             data_set($data, 'effects.html', $html);
-        }
-        else
-        {
+        } else {
             // livewire v3
-            foreach (data_get($data, 'components.*.effects.html') as $componentIndex => $componentHtml)
-            {
+            foreach (data_get($data, 'components.*.effects.html') as $componentIndex => $componentHtml) {
                 $html = BladeManager::renderContent($componentHtml);
                 data_set($data, "components.$componentIndex.effects.html", $html);
             }

--- a/src/Middleware/RenderTorchlight.php
+++ b/src/Middleware/RenderTorchlight.php
@@ -47,9 +47,22 @@ class RenderTorchlight
 
         $data = $response->getData();
 
-        $html = BladeManager::renderContent(data_get($data, 'effects.html'));
+        if (data_get($data, 'effects.html'))
+        {
+            // livewire v2
+            $html = BladeManager::renderContent(data_get($data, 'effects.html'));
 
-        data_set($data, 'effects.html', $html);
+            data_set($data, 'effects.html', $html);
+        }
+        else
+        {
+            // livewire v3
+            foreach (data_get($data, 'components.*.effects.html') as $componentIndex => $componentHtml)
+            {
+                $html = BladeManager::renderContent($componentHtml);
+                data_set($data, "components.$componentIndex.effects.html", $html);
+            }
+        }
 
         return $response->setData($data);
     }


### PR DESCRIPTION
In Livewire V3 the response data looks different than livewire V2. Here are the differences: 

Livewire V2: 
<img width="1076" alt="Scherm­afbeelding 2023-10-25 om 15 39 59" src="https://github.com/torchlight-api/torchlight-laravel/assets/114000210/8caf4f01-1020-4b12-b8eb-e4db6ec17fb4">

Livewire V3: 
<img width="993" alt="Scherm­afbeelding 2023-10-25 om 15 38 52" src="https://github.com/torchlight-api/torchlight-laravel/assets/114000210/5dbe8aa3-5dbf-493c-96a2-44f4fc617614">

This means `data_get($data, 'effects.html')` will return `null` if livewire V3 is being used. To enable both livewire versions, I'd suggest checking if null is returned and if so, loop over the components array . If not, I'd keep the original logic.

I have verified these changes work for one or multiple updating components with livewire V3. 
