### PR TITLE
Allow components to read contents from any file handlers

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -163,8 +163,9 @@ class Manager
                 $directory = Str::finish($directory, DIRECTORY_SEPARATOR);
             }
 
-            if (is_file($directory . $file)) {
-                return file_get_contents($directory . $file);
+            $contents = @file_get_contents($directory . $file);
+            if ($contents) {
+                return $contents;
             }
         }
 


### PR DESCRIPTION
Hi,

Currently, 
```php
<x-torchlight-code contents="https://gist.githubusercontent.com/..." />
```
does not work because of the `is_file` condition which reduces what we can accept to  the `file://` wrapper instead of all the [stream wrappers](https://www.php.net/manual/en/wrappers.php). 

The above is only one example, here's another, when using Stripe's [markdoc.dev](markdoc.dev), which is not ported to PHP (yet), one can simply convert the fence node (codeblock) to the blade equivalent without messing with the torchlight-cli:
```js
const fence = {
  render 'pre',
  // ...
  transform(node, config) {
      const attributes = node.transformAttributes(config);

      return new Tag('pre', {}, [
          new Tag('x-torchlight-code', {
              language: node.attributes.language,
              "contents": "data://text/plain;base64," + btoa(node.attributes.content)
          }, [])
      ])
    }
}
```
The `<x-torchlight-code contents="data://text/plain;base64,...">` produced then works without any changes, assuming the middleware is registered and 'snippet_directories' is empty.

#### Security

This does not create new potential security issues as before this PR, `":contents='$userInput'"` was already insecure unless the `$userInput` was sanitizied, and if it was sanitizied, then this change does not create new risks.
